### PR TITLE
View Bob Toggle (#96)

### DIFF
--- a/addons/sourcemod/scripting/sf2/extras/commands.sp
+++ b/addons/sourcemod/scripting/sf2/extras/commands.sp
@@ -286,6 +286,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_slafk", Command_NoPoints);
 	RegConsoleCmd("sm_flashlight", Command_ToggleFlashlight);
 	RegConsoleCmd("sm_slhud", Command_MenuSwitchHud);
+	RegConsoleCmd("sm_slviewbob", Command_MenuViewBob);
 	RegConsoleCmd("+sprint", Command_SprintOn);
 	RegConsoleCmd("-sprint", Command_SprintOff);
 	RegConsoleCmd("+blink", Command_BlinkOn);
@@ -474,6 +475,27 @@ static Action Command_MenuSwitchHud(int client,int args)
 	DrawPanelItem(panel, "Use the legacy HUD");
 
 	SendPanelToClient(panel, client, Panel_SettingsHudVersion, 30);
+	delete panel;
+	return Plugin_Handled;
+}
+
+static Action Command_MenuViewBob(int client,int args)
+{
+	if (!g_Enabled)
+	{
+		return Plugin_Continue;
+	}
+
+	char buffer[512];
+	FormatEx(buffer, sizeof(buffer), "%T\n \n", "SF2 Settings View Bobbing Toggle Title", client);
+
+	Handle panel = CreatePanel();
+	SetPanelTitle(panel, buffer);
+
+	DrawPanelItem(panel, "Enable View Bobbing");
+	DrawPanelItem(panel, "Disable View Bobbing");
+
+	SendPanelToClient(panel, client, Panel_SettingsViewBobbing, 30);
 	delete panel;
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/sf2/menus.sp
+++ b/addons/sourcemod/scripting/sf2/menus.sp
@@ -147,6 +147,8 @@ void SetupMenus()
 	AddMenuItem(g_MenuSettings, "0", buffer);
 	FormatEx(buffer, sizeof(buffer), "%t", "SF2 Settings Hud Version Title");
 	AddMenuItem(g_MenuSettings, "0", buffer);
+	FormatEx(buffer, sizeof(buffer), "%t", "SF2 Settings View Bobbing Toggle Title");
+	AddMenuItem(g_MenuSettings, "0", buffer);
 	SetMenuExitBackButton(g_MenuSettings, true);
 
 	g_MenuSettingsFlashlightTemp1 = CreateMenu(Menu_Settings_Flashlighttemp1);
@@ -1067,6 +1069,10 @@ public int Menu_Settings(Handle menu, MenuAction action,int param1,int param2)
 				SendPanelToClient(panel, param1, Panel_SettingsHudVersion, 30);
 				delete panel;
 			}
+			case 10:
+			{
+				FakeClientCommand(param1, "sm_slviewbob");
+			}
 		}
 	}
 	else if (action == MenuAction_Cancel)
@@ -1350,6 +1356,30 @@ public int Panel_SettingsHudVersion(Handle menu, MenuAction action,int param1,in
 				g_PlayerPreferences[param1].PlayerPreference_LegacyHud = true;
 				ClientSaveCookies(param1);
 				CPrintToChat(param1, "%T", "SF2 Legacy Hud Use", param1);
+			}
+		}
+
+		DisplayMenu(g_MenuSettings, param1, 30);
+	}
+}
+
+public int Panel_SettingsViewBobbing(Handle menu, MenuAction action,int param1,int param2)
+{
+	if (action == MenuAction_Select)
+	{
+		switch (param2)
+		{
+			case 1:
+			{
+				g_PlayerPreferences[param1].PlayerPreference_ViewBobbing = true;
+				ClientSaveCookies(param1);
+				CPrintToChat(param1, "%T", "SF2 Toggle View Bobbing On", param1);
+			}
+			case 2:
+			{
+				g_PlayerPreferences[param1].PlayerPreference_ViewBobbing = false;
+				ClientSaveCookies(param1);
+				CPrintToChat(param1, "%T", "SF2 Toggle View Bobbing Off", param1);
 			}
 		}
 

--- a/addons/sourcemod/translations/sf2.phrases.txt
+++ b/addons/sourcemod/translations/sf2.phrases.txt
@@ -1741,6 +1741,21 @@
 		"fi"	"{lightblue}Haamu tila otetaan nyt käyttöön, kun kuolet RED:llä."
 	}
 
+	"SF2 Settings View Bobbing Toggle Title"
+	{
+		"en" 	"Set view bobbing toggle"
+	}
+
+	"SF2 Toggle View Bobbing On"
+	{
+		"en"	"{lightblue}View bobbing is now enabled."
+	}
+
+	"SF2 Toggle View Bobbing Off"
+	{
+		"en"	"{lightblue}View bobbing is now disabled."
+	}
+
 	"SF2 Recent Changes"
 	{
 		"en"	"Recent Changes:"


### PR DESCRIPTION
Allows players to toggle having view bobbing enabled or disabled as there were no way to change the setting once you joined the server for the first time.